### PR TITLE
GitHub Action to pip install jack

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,7 +1,7 @@
-name: pytest
+name: pip_install_jack
 on: [pull_request, push]
 jobs:
-  pytest:
+  pip_install_jack:
     strategy:
       fail-fast: false
       matrix:
@@ -13,6 +13,5 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install --upgrade pip wheel
-      - run: pip install .
-      - run: pip install pytest
-      - run: pytest .
+      - run: pip install jack
+      # - run: pip install .

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,17 @@
+name: lint_python
+on: [pull_request, push]
+jobs:
+  lint_python:
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "pypy39"]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: pip install --upgrade pip wheel
+      - run: pip install pytest
+      - run: pytest --doctest-modules . || pytest .

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,7 +1,7 @@
-name: lint_python
+name: pytest
 on: [pull_request, push]
 jobs:
-  lint_python:
+  pytest:
     strategy:
       fail-fast: false
       matrix:
@@ -13,5 +13,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install --upgrade pip wheel
+      - run: pip install .
       - run: pip install pytest
       - run: pytest .

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "pypy39"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "pypy3.9"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -14,4 +14,4 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - run: pip install --upgrade pip wheel
       - run: pip install pytest
-      - run: pytest --doctest-modules . || pytest .
+      - run: pytest .


### PR DESCRIPTION
Demonstrate the pytest failure on Python 3.11.
Blocking: https://github.com/Homebrew/homebrew-core/pull/119011
Test results: https://github.com/cclauss/jack/actions